### PR TITLE
Feature/teams controller create team

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -10,6 +10,8 @@ app.disable("x-powered-by");
 
 app.use(morgan("dev"));
 
+app.use(express.json());
+
 detectEnviromentForCors(app);
 
 app.use("/teams", teamsRouter);

--- a/src/team/controller/TeamsController.ts
+++ b/src/team/controller/TeamsController.ts
@@ -22,9 +22,9 @@ class TeamsController implements TeamsControllerStructure {
 
     const { name } = req.body as TeamWithoutId;
 
-    const existingTeam = await Team.findOne({ name });
+    const teamInDataBase = await Team.findOne({ name });
 
-    if (existingTeam) {
+    if (teamInDataBase) {
       throw new ServerError(
         "A team with this name already exists",
         statusCodeError,

--- a/src/team/controller/TeamsController.ts
+++ b/src/team/controller/TeamsController.ts
@@ -1,7 +1,9 @@
 import { type Model } from "mongoose";
 import { type Request, type Response } from "express";
 import { type TeamsControllerStructure } from "./types";
-import { type TeamStructure } from "../types";
+import { type TeamWithoutId, type TeamStructure } from "../types";
+import Team from "../model/Team.js";
+import ServerError from "../../server/errors/ServerError/ServerError.js";
 
 class TeamsController implements TeamsControllerStructure {
   constructor(private readonly teamModel: Model<TeamStructure>) {}
@@ -12,6 +14,26 @@ class TeamsController implements TeamsControllerStructure {
     const teams = await this.teamModel.find().sort({ name: 1 }).exec();
 
     res.status(statusCode).json({ teams });
+  };
+
+  createTeam = async (req: Request, res: Response): Promise<void> => {
+    const statusCodeError = 409;
+    const statusCode = 201;
+
+    const { name } = req.body as TeamWithoutId;
+
+    const existingTeam = await Team.findOne({ name });
+
+    if (existingTeam) {
+      throw new ServerError(
+        "A team with this name already exists",
+        statusCodeError,
+      );
+    }
+
+    const newTeam = await this.teamModel.create(req.body as TeamWithoutId);
+
+    res.status(statusCode).json({ teams: newTeam });
   };
 }
 

--- a/src/team/controller/__tests__/createTeam.test.ts
+++ b/src/team/controller/__tests__/createTeam.test.ts
@@ -1,0 +1,53 @@
+import { type Model } from "mongoose";
+import { type Response, type Request } from "express";
+import { type TeamStructure, type TeamWithoutId } from "../../types";
+import TeamsController from "../TeamsController";
+import Team from "../../model/Team";
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("Given the method createTeam of TeamsController class", () => {
+  describe("When it receives a request with the 'Aniol's team'", () => {
+    const aniolTeam: TeamWithoutId = {
+      name: "Aniol's team",
+      ridersNames: ["juan", "berto"],
+      championshipTitles: 2,
+      imageUrl: "http://refactor",
+      altImageText: "Aniol's images",
+      description: "Aniol's hola hola",
+      debutYear: 1996,
+      isOfficialTeam: true,
+    };
+
+    const teamModelMock: Partial<Model<TeamStructure>> = {
+      findOne: (Team.findOne = jest.fn().mockResolvedValue(null)),
+      create: jest.fn().mockResolvedValue(aniolTeam),
+    };
+
+    const teamsController = new TeamsController(
+      teamModelMock as Model<TeamStructure>,
+    );
+
+    const req: Partial<Request> = { body: aniolTeam };
+    const res: Partial<Response> = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+
+    test("Then it should call the response's method status with 201", async () => {
+      const expectedStatusCode = 201;
+
+      await teamsController.createTeam(req as Request, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(expectedStatusCode);
+    });
+
+    test("Then it should call the response's method json with the 'Aniol's team'", async () => {
+      await teamsController.createTeam(req as Request, res as Response);
+
+      expect(res.json).toHaveBeenCalledWith({ teams: aniolTeam });
+    });
+  });
+});

--- a/src/team/controller/types.ts
+++ b/src/team/controller/types.ts
@@ -2,4 +2,5 @@ import { type Request, type Response } from "express";
 
 export interface TeamsControllerStructure {
   getTeams: (_req: Request, res: Response) => void;
+  createTeam: (req: Request, res: Response) => void;
 }

--- a/src/team/model/teamSchema.ts
+++ b/src/team/model/teamSchema.ts
@@ -1,39 +1,43 @@
 import { Schema } from "mongoose";
 import { type TeamStructure } from "../types";
 
-const teamSchema = new Schema<TeamStructure>({
-  name: {
-    type: String,
-    required: true,
+const teamSchema = new Schema<TeamStructure>(
+  {
+    name: {
+      type: String,
+      unique: true,
+      required: true,
+    },
+    ridersNames: {
+      type: [String],
+      required: true,
+    },
+    championshipTitles: {
+      type: Number,
+      required: true,
+    },
+    imageUrl: {
+      type: String,
+      required: true,
+    },
+    altImageText: {
+      type: String,
+      required: true,
+    },
+    description: {
+      type: String,
+      required: true,
+    },
+    debutYear: {
+      type: Number,
+      required: true,
+    },
+    isOfficialTeam: {
+      type: Boolean,
+      required: true,
+    },
   },
-  ridersNames: {
-    type: [String],
-    required: true,
-  },
-  championshipTitles: {
-    type: Number,
-    required: true,
-  },
-  imageUrl: {
-    type: String,
-    required: true,
-  },
-  altImageText: {
-    type: String,
-    required: true,
-  },
-  description: {
-    type: String,
-    required: true,
-  },
-  debutYear: {
-    type: Number,
-    required: true,
-  },
-  isOfficialTeam: {
-    type: Boolean,
-    required: true,
-  },
-});
+  { versionKey: false },
+);
 
 export default teamSchema;

--- a/src/team/router/teamsRouter.ts
+++ b/src/team/router/teamsRouter.ts
@@ -7,5 +7,6 @@ const teamsRouter = Router();
 const teamsController = new TeamsController(Team);
 
 teamsRouter.get("/", teamsController.getTeams);
+teamsRouter.post("/", teamsController.createTeam);
 
 export default teamsRouter;

--- a/src/team/types.ts
+++ b/src/team/types.ts
@@ -9,3 +9,5 @@ export interface TeamStructure {
   debutYear: number;
   isOfficialTeam: boolean;
 }
+
+export type TeamWithoutId = Omit<TeamStructure, "_id">;


### PR DESCRIPTION
- Added createTeam method to TeamsController. This method find a team with name property in the database and if it doesn't exists it creates one with the request body if it contains the properties defined in the `teamSchema`.
- Set name field as unique in teamSchema.
- Added route for creating a team in teamRouter
- Added tests cases for createTeam method. Tested response status and json methods
