### PR TITLE
Fix createTeam method using constructor teamModel. Change req.body type

### DIFF
--- a/src/team/controller/TeamsController.ts
+++ b/src/team/controller/TeamsController.ts
@@ -1,8 +1,7 @@
 import { type Model } from "mongoose";
 import { type Request, type Response } from "express";
 import { type TeamsControllerStructure } from "./types";
-import { type TeamWithoutId, type TeamStructure } from "../types";
-import Team from "../model/Team.js";
+import { type TeamStructure } from "../types";
 import ServerError from "../../server/errors/ServerError/ServerError.js";
 
 class TeamsController implements TeamsControllerStructure {
@@ -20,9 +19,9 @@ class TeamsController implements TeamsControllerStructure {
     const statusCodeError = 409;
     const statusCode = 201;
 
-    const { name } = req.body as TeamWithoutId;
+    const { name } = req.body as TeamStructure;
 
-    const teamInDataBase = await Team.findOne({ name });
+    const teamInDataBase = await this.teamModel.findOne({ name });
 
     if (teamInDataBase) {
       throw new ServerError(
@@ -31,7 +30,7 @@ class TeamsController implements TeamsControllerStructure {
       );
     }
 
-    const newTeam = await this.teamModel.create(req.body as TeamWithoutId);
+    const newTeam = await this.teamModel.create(req.body);
 
     res.status(statusCode).json({ teams: newTeam });
   };

--- a/src/team/controller/__tests__/createTeam.test.ts
+++ b/src/team/controller/__tests__/createTeam.test.ts
@@ -2,7 +2,6 @@ import { type Model } from "mongoose";
 import { type Response, type Request } from "express";
 import { type TeamStructure, type TeamWithoutId } from "../../types";
 import TeamsController from "../TeamsController";
-import Team from "../../model/Team";
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -22,7 +21,7 @@ describe("Given the method createTeam of TeamsController class", () => {
     };
 
     const teamModelMock: Partial<Model<TeamStructure>> = {
-      findOne: (Team.findOne = jest.fn().mockResolvedValue(null)),
+      findOne: jest.fn().mockResolvedValue(null),
       create: jest.fn().mockResolvedValue(aniolTeam),
     };
 


### PR DESCRIPTION
- Fixed `TeamsController`createTeam method to use the `teamModel`from class constructor
- Changed type for req.body in createTeam method
- Updated test mock with the previous changes.