### PR TITLE
Feature/teams controller delete by

### DIFF
--- a/src/team/controller/TeamsController.ts
+++ b/src/team/controller/TeamsController.ts
@@ -1,6 +1,10 @@
 import { type Model } from "mongoose";
 import { type Request, type Response } from "express";
-import { type TeamsControllerStructure } from "./types";
+import {
+  type RequestWithId,
+  type RequestWithTeam,
+  type TeamsControllerStructure,
+} from "./types";
 import { type TeamStructure } from "../types";
 import ServerError from "../../server/errors/ServerError/ServerError.js";
 
@@ -15,11 +19,11 @@ class TeamsController implements TeamsControllerStructure {
     res.status(statusCode).json({ teams });
   };
 
-  createTeam = async (req: Request, res: Response): Promise<void> => {
+  createTeam = async (req: RequestWithTeam, res: Response): Promise<void> => {
     const statusCodeError = 409;
     const statusCode = 201;
 
-    const { name } = req.body as TeamStructure;
+    const { name } = req.body;
 
     const teamInDataBase = await this.teamModel.findOne({ name });
 
@@ -33,6 +37,25 @@ class TeamsController implements TeamsControllerStructure {
     const newTeam = await this.teamModel.create(req.body);
 
     res.status(statusCode).json({ teams: newTeam });
+  };
+
+  deleteById = async (req: RequestWithId, res: Response): Promise<void> => {
+    const idLength = 24;
+    const statusCode = 200;
+
+    const { _id } = req.params;
+
+    if (_id.length !== idLength) {
+      throw new ServerError("ID is not correct", 400);
+    }
+
+    const teamInDataBase = await this.teamModel.findByIdAndDelete(_id);
+
+    if (!teamInDataBase) {
+      throw new ServerError("Team not found", 404);
+    }
+
+    res.status(statusCode).json({ message: "Team deleted" });
   };
 }
 

--- a/src/team/controller/__tests__/createTeam.test.ts
+++ b/src/team/controller/__tests__/createTeam.test.ts
@@ -1,7 +1,8 @@
 import { type Model } from "mongoose";
-import { type Response, type Request } from "express";
+import { type Response } from "express";
 import { type TeamStructure, type TeamWithoutId } from "../../types";
 import TeamsController from "../TeamsController";
+import { type RequestWithTeam } from "../types";
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -29,7 +30,7 @@ describe("Given the method createTeam of TeamsController class", () => {
       teamModelMock as Model<TeamStructure>,
     );
 
-    const req: Partial<Request> = { body: aniolTeam };
+    const req: Partial<RequestWithTeam> = { body: aniolTeam };
     const res: Partial<Response> = {
       status: jest.fn().mockReturnThis(),
       json: jest.fn(),
@@ -38,13 +39,13 @@ describe("Given the method createTeam of TeamsController class", () => {
     test("Then it should call the response's method status with 201", async () => {
       const expectedStatusCode = 201;
 
-      await teamsController.createTeam(req as Request, res as Response);
+      await teamsController.createTeam(req as RequestWithTeam, res as Response);
 
       expect(res.status).toHaveBeenCalledWith(expectedStatusCode);
     });
 
     test("Then it should call the response's method json with the 'Aniol's team'", async () => {
-      await teamsController.createTeam(req as Request, res as Response);
+      await teamsController.createTeam(req as RequestWithTeam, res as Response);
 
       expect(res.json).toHaveBeenCalledWith({ teams: aniolTeam });
     });

--- a/src/team/controller/__tests__/deleteById.tes.ts
+++ b/src/team/controller/__tests__/deleteById.tes.ts
@@ -1,0 +1,56 @@
+import { type Model } from "mongoose";
+import { type Response } from "express";
+import { type TeamStructure } from "../../types";
+import { type RequestWithId } from "../types";
+import TeamsController from "../TeamsController";
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("Given the deleteById method of the TeamsController class", () => {
+  const aniolTeam: TeamStructure = {
+    _id: "6760222c9f350126a80dcb71",
+    name: "Aniol's team",
+    ridersNames: ["juan", "berto"],
+    championshipTitles: 2,
+    imageUrl: "https://refractor.com",
+    altImageText: "Aniol's images",
+    description: "Aniol's hola hola",
+    debutYear: 1996,
+    isOfficialTeam: true,
+  };
+
+  const teamModelMock: Partial<Model<TeamStructure>> = {
+    findByIdAndDelete: jest.fn().mockResolvedValue(aniolTeam),
+  };
+
+  const teamsController = new TeamsController(
+    teamModelMock as Model<TeamStructure>,
+  );
+
+  const req: Partial<RequestWithId> = {
+    params: { _id: aniolTeam._id },
+  };
+
+  const res: Partial<Response> = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn(),
+  };
+
+  describe("When it receives a request with a valid id'", () => {
+    test("Then it should call the response's method with status 200", async () => {
+      const expectedStatusCode = 200;
+
+      await teamsController.deleteById(req as RequestWithId, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(expectedStatusCode);
+    });
+
+    test("Then it should call the response's method json with the 'Team deleted'", async () => {
+      await teamsController.deleteById(req as RequestWithId, res as Response);
+
+      expect(res.json).toHaveBeenCalledWith({ message: "Team deleted" });
+    });
+  });
+});

--- a/src/team/controller/__tests__/deleteById.test.ts
+++ b/src/team/controller/__tests__/deleteById.test.ts
@@ -48,9 +48,11 @@ describe("Given the deleteById method of the TeamsController class", () => {
     });
 
     test("Then it should call the response's method json with the 'Team deleted'", async () => {
+      const expectedMessage = "Team deleted";
+
       await teamsController.deleteById(req as RequestWithId, res as Response);
 
-      expect(res.json).toHaveBeenCalledWith({ message: "Team deleted" });
+      expect(res.json).toHaveBeenCalledWith({ message: expectedMessage });
     });
   });
 });

--- a/src/team/controller/types.ts
+++ b/src/team/controller/types.ts
@@ -1,6 +1,14 @@
 import { type Request, type Response } from "express";
+import { type TeamWithoutId } from "../types";
 
 export interface TeamsControllerStructure {
-  getTeams: (_req: Request, res: Response) => void;
-  createTeam: (req: Request, res: Response) => void;
+  getTeams: (_req: Request, res: Response) => Promise<void>;
+  createTeam: (req: Request, res: Response) => Promise<void>;
+  deleteById: (req: Request, res: Response) => Promise<void>;
 }
+
+export type RequestWithTeam = Request<unknown, unknown, TeamWithoutId>;
+
+export type RequestWithId = Request<{
+  _id: string;
+}>;

--- a/src/team/router/__tests__/deleteByIdEndpoint.test.ts
+++ b/src/team/router/__tests__/deleteByIdEndpoint.test.ts
@@ -1,0 +1,72 @@
+import { MongoMemoryServer } from "mongodb-memory-server";
+import request from "supertest";
+import mongoose from "mongoose";
+import connectToDatabase from "../../../database/connectToDatabase";
+import { app } from "../../../server";
+import Team from "../../model/Team";
+
+let server: MongoMemoryServer;
+
+beforeAll(async () => {
+  server = await MongoMemoryServer.create();
+  const connectionString = server.getUri();
+
+  await connectToDatabase(connectionString);
+});
+
+afterAll(async () => {
+  await server.stop();
+  await mongoose.connection.close();
+});
+
+describe("Given the DELETE /teams/:id endpoint", () => {
+  describe("When it receives a request with a valid id", () => {
+    test("Then it should respond with the status 200 and a 'Team deleted''", async () => {
+      const expectedStatusCode = 200;
+      const expectedMessage = "Team deleted";
+
+      const newTeam = await Team.create({
+        name: "Aniol's team",
+        ridersNames: ["juan", "berto"],
+        championshipTitles: 2,
+        imageUrl: "http://refactor",
+        altImageText: "kljkl",
+        description: "kljkl",
+        debutYear: 1996,
+        isOfficialTeam: true,
+      });
+
+      const response = await request(app)
+        .delete(`/teams/${newTeam._id}`)
+        .expect(expectedStatusCode);
+
+      expect(response.body).toEqual({
+        message: expectedMessage,
+      });
+    });
+  });
+
+  describe("When it receive a request with an '123456789123456789123456' inexistent id", () => {
+    test("Then it should respond with the status 404 and a 'Team not found'", async () => {
+      const response = await request(app)
+        .delete("/teams/123456789123456789123456")
+        .expect(404);
+
+      expect(response.body).toEqual({
+        message: "Team not found",
+      });
+    });
+  });
+
+  describe("When it receive a request with an '1234567891234567891234' incorrect id", () => {
+    test("Then it should respond with the status 400 and a 'ID is not correct'", async () => {
+      const response = await request(app)
+        .delete("/teams/1234567891234567891234")
+        .expect(400);
+
+      expect(response.body).toEqual({
+        message: "ID is not correct",
+      });
+    });
+  });
+});

--- a/src/team/router/teamsRouter.ts
+++ b/src/team/router/teamsRouter.ts
@@ -8,5 +8,6 @@ const teamsController = new TeamsController(Team);
 
 teamsRouter.get("/", teamsController.getTeams);
 teamsRouter.post("/", teamsController.createTeam);
+teamsRouter.delete("/:_id", teamsController.deleteById);
 
 export default teamsRouter;


### PR DESCRIPTION
- Added `RequestWithTeam` and `RequestWithId` types.  `RequestWithTeam` types req.body of createTeam method and `RequestWithId` types `deleteById` test
- Created `deleteById` method and correct req.body type of createTeam. This method deletes the team that match with the given `_id` and if there is an incorrect `_id` or `_id` is not in the database will through a `ServerError`
- Added route for delete endpoint.
- Add tests cases for `deleteById` TeamsController method. Tested that status and json method are called.
- Add tests cases for `deleteByIdEndpoint`. Tested happy path and mentioned error cases.